### PR TITLE
Bd2k test

### DIFF
--- a/tools/delly/Dockerfile
+++ b/tools/delly/Dockerfile
@@ -14,7 +14,7 @@ MAINTAINER Tobias Rausch rausch@embl.de
 RUN apt-get update
 
 # install g++, git, zlib, cmake, boost, ...
-RUN apt-get install -y build-essential g++ git cmake zlib1g-dev libboost-date-time-dev libboost-program-options-dev libboost-system-dev libboost-filesystem-dev libboost-iostreams-dev python
+RUN apt-get install -y build-essential g++ git cmake zlib1g-dev libbz2-dev libboost-date-time-dev libboost-program-options-dev libboost-system-dev libboost-filesystem-dev libboost-iostreams-dev python
 RUN apt-get install -y python-pip samtools
 RUN pip install PyVCF
 


### PR DESCRIPTION
These are changes that were necessary to build the individual tool images via warpdrive.py ( python nebula/nebula/warpdrive.py build -o images/ tools/ ) on my local machine and on Amazon's EC2.
1. Fix missing dependency on Bzip2
2. Remove biobambam_merge.xml
